### PR TITLE
Return path field when listing the conversations that I’m included in.

### DIFF
--- a/src/objs/nkchat_conversation_obj.erl
+++ b/src/objs/nkchat_conversation_obj.erl
@@ -109,7 +109,7 @@ get_member_conversations(Srv, Domain, MemberId) ->
             },
             Search2 = #{
                 sort => [#{created_time => #{order => desc}}],
-                fields => [created_time, description, <<?CHAT_CONVERSATION/binary, ".member_ids">>],
+                fields => [created_time, path, description, <<?CHAT_CONVERSATION/binary, ".member_ids">>],
                 filters => Filters
             },
             case nkdomain_store:find(SrvId, Search2) of


### PR DESCRIPTION
This way, the client can list the conversation name by manually parsing the path (until a proper name is stored in the conversation object)