### PR TITLE
Added subtype field to some responses.

### DIFF
--- a/src/objs/nkchat_conversation_obj.erl
+++ b/src/objs/nkchat_conversation_obj.erl
@@ -126,7 +126,7 @@ get_member_conversations(Srv, Domain, MemberId) ->
             },
             Search2 = #{
                 sort => [#{created_time => #{order => desc}}],
-                fields => [created_time, description, name, path, <<?CHAT_CONVERSATION/binary, ".members.member_id">>],
+                fields => [created_time, description, name, path, subtype, <<?CHAT_CONVERSATION/binary, ".members.member_id">>],
                 filters => Filters
             },
             case nkdomain_store:find(SrvId, Search2) of
@@ -396,6 +396,7 @@ object_sync_op({?MODULE, get_session_info}, _From, #obj_session{obj_id=ObjId}=Se
         obj_id => ObjId,
         name => Name,
         path => Path,
+        subtype => maps:get(subtype, Obj, <<>>),
         description => maps:get(description, Obj, <<>>),
         is_enabled => Enabled,
         member_ids => MemberIds

--- a/src/objs/nkchat_session_obj.erl
+++ b/src/objs/nkchat_session_obj.erl
@@ -308,7 +308,7 @@ object_sync_op({?MODULE, set_active_conv, ConvId}, _From, Session) ->
                     Now = nklib_util:m_timestamp(),
                     Conv2 = Conv#{
                         last_active_time => Now,
-                        last_seen_message_id => Now
+                        last_seen_message_time => Now
                     },
                     SessConv2 = SessConv#{
                         unread_count => 0


### PR DESCRIPTION
This field wasn’t present in chat.session->start, chat.session->get_all_conversations and conversation->get_member_conversations
Also corrected a bug that updated last_seen_message_id instead of last_seen_message_time when a conversation was marked as active