### PR TITLE
Changed the sorting order to use the channel name.

### DIFF
--- a/src/objs/nkchat_conversation_obj.erl
+++ b/src/objs/nkchat_conversation_obj.erl
@@ -118,7 +118,7 @@ get_member_conversations(Srv, Domain, MemberId) ->
                 << ?CHAT_CONVERSATION/binary, ".members.member_id">> => MemberId
             },
             Search2 = #{
-                sort => [#{created_time => #{order => desc}}],
+                sort => [#{"name.keyword" => #{order => asc}}],
                 fields => [created_time, description, name, path, subtype, <<?CHAT_CONVERSATION/binary, ".members.member_id">>],
                 filters => Filters,
                 size => 9999


### PR DESCRIPTION
This change will also order the name used for direct messages (“username1 - username2”). By using this new order, no matter which user request this data, it would be ordered by channel_name/user_id after the list is splitted in channels and direct messages.