### PR TITLE
fixed typo

### DIFF
--- a/src/objs/nkchat_media_session_obj.erl
+++ b/src/objs/nkchat_media_session_obj.erl
@@ -413,7 +413,7 @@ object_sync_op({?MODULE, call_hangup, CallId}, _From, #?STATE{srv_id=SrvId}=Stat
         #call{pid=Pid, role=Role} ->
             Reason = case Role of
                 caller -> caller_hangup;
-                callee -> calee_hangup
+                callee -> callee_hangup
             end,
             Reply = nkchat_media_call_obj:hangup_call(SrvId, Pid, Reason),
             {reply, Reply, State};


### PR DESCRIPTION
Fixed minor typo, detected by test automation: calee -> callee