### PR TITLE
Ng2

### DIFF
--- a/src/objs/nkchat_conversation_obj.erl
+++ b/src/objs/nkchat_conversation_obj.erl
@@ -197,11 +197,11 @@ find_conversations_with_members(SrvId, Domain, MemberIds) ->
                 size => 9999
             },
             case nkdomain:search(SrvId, Search2) of
-                {ok, _N, List, _Meta} ->
+                {ok, N, List, _Meta} ->
                     List2 = lists:map(
                         fun(#{<<"obj_id">>:=ConvId, ?CHAT_CONVERSATION:=#{<<"type">>:=Type}}) -> {ConvId, Type} end,
                         List),
-                    {ok, List2};
+                    {ok, N, List2};
                 {error, Error} ->
                     {error, Error}
             end;

--- a/src/objs/nkchat_conversation_obj_api.erl
+++ b/src/objs/nkchat_conversation_obj_api.erl
@@ -89,9 +89,9 @@ cmd(<<"find_conversations_with_members">>, #nkreq{data=Data, srv_id=SrvId}=Req) 
         {ok, DomainId} ->
             #{member_ids:=MemberIds} = Data,
             case nkchat_conversation_obj:find_conversations_with_members(SrvId, DomainId, MemberIds) of
-                {ok, List} ->
+                {ok, Total, List} ->
                     List2 = [#{<<"conversation_id">>=>ConvId, <<"type">>=>Type} || {ConvId, Type}<-List],
-                    {ok, #{<<"data">>=>List2}};
+                    {ok, #{<<"total">> => Total, <<"data">>=>List2}};
                 {error, Error} ->
                     {error, Error}
             end;


### PR DESCRIPTION
Small PR that adds a "total" field to the response returned by find_conversations_with_members. This should bring consistency with other responses that return lists in the form: { data: { data: [...], total: x }}.

This is the test that backs up this code change: 

1. Feature: Sipstorm conversations  # features/sipstorm/conversations.feature

    3. Scenario: Find conversations by members (no results)
        1. Given Netcomp is installed
        2. And I have a fresh database
        3. And I am logged in into c4 as user admin with password netcomposer
        4. And I have a chat session in c4
        5. And I have a contact with name test, password test and email test@test.com
        6. When I find my conversations with that contact
        7. Then I should have a list having a total
        8. And that response should have total equal to 0
