### PR TITLE
Added conversation parent_id

### DIFF
--- a/src/objs/nkchat_conversation_obj.erl
+++ b/src/objs/nkchat_conversation_obj.erl
@@ -1228,6 +1228,7 @@ do_get_member_info(Member, State) ->
     #member{unread_count=Counter} = Member,
     #{
         path:=Path,
+        parent_id:=ParentId,
         ?CHAT_CONVERSATION:=#{
             type:=Type,
             members:=Members,
@@ -1237,6 +1238,7 @@ do_get_member_info(Member, State) ->
         }
     } = Obj,
     #{
+        parent_id => ParentId,
         name => maps:get(name, Obj, <<>>),
         description => maps:get(description, Obj, <<>>),
         type => Type,


### PR DESCRIPTION
This information is needed to be able to get the encounter_id from the associated conversation (and thus, be able to resolve a case from that conversation)