### PR TITLE
Added start_date, end_date and inclusive parameters to get messages by date

### DIFF
--- a/src/objs/nkchat_conversation_obj_syntax.erl
+++ b/src/objs/nkchat_conversation_obj_syntax.erl
@@ -63,9 +63,11 @@ syntax(<<"find_conversations_with_members">>, Syntax) ->
 syntax(<<"get_messages">>, Syntax) ->
     Syntax#{
         id => binary,
-        size => integer,
         from => integer,
+        size => integer,
         start_date => integer,
+        end_date => integer,
+        inclusive => boolean,
         '__mandatory' => [id]
     };
 


### PR DESCRIPTION
- start_date: used to get messages older than a certain date ("from" field is ignored, "size" indicates the number of desired results).
- end_date: used to get messages newer than a certain date ("from" field is ignored, "size" indicates the number of desired results).
- When both dates are selected, "size" field is also ignored.
- inclusive: used to determine if the selected dates are inclusive (true) or not (false or absent).