### PR TITLE
Changed query_member_conversations to search conversations in depth by domain

### DIFF
--- a/src/objs/nkchat_conversation_obj.erl
+++ b/src/objs/nkchat_conversation_obj.erl
@@ -241,12 +241,12 @@ object_mutation(MutationName, Params, Ctx) ->
 
 %% @doc
 object_db_get_query(nkelastic, {query_member_conversations, Domain, Member}, DbOpts) ->
-    case nkdomain_store_es_util:get_obj_id(Domain) of
-        {ok, DomainId} ->
+    case nkdomain_store_es_util:get_path(Domain) of
+        {ok, DomainPath} ->
             case nkdomain_store_es_util:get_obj_id(Member) of
                 {ok, MemberId} ->
                     Filters = [
-                        {domain_id, eq, DomainId},
+                        {path, subdir, DomainPath},
                         {[?CHAT_CONVERSATION, ".members.member_id"], eq, MemberId}
                     ],
                     Opts = #{

--- a/src/objs/nkchat_conversation_obj_view.erl
+++ b/src/objs/nkchat_conversation_obj_view.erl
@@ -125,7 +125,7 @@ view(Obj, IsNew, #admin_session{domain_id=Domain}=Session) ->
                         suggest_type => ?DOMAIN_USER,
                         suggest_field => <<"user_name">>,
                         suggest_template => <<"#user_name# #user_surname#">>,
-                        required => AllowMembersEdit, %true
+                        required => false,
                         editable => AllowMembersEdit, %true
                         options => MemberOpts
                     }


### PR DESCRIPTION
Instead of return only conversations in the same domain as the user.
Also changed conversation form to allow the creation of channels without users.