### PR TITLE
Added duration field and fixed call duration calculation

### DIFF
--- a/src/objs/nkchat_message_obj.erl
+++ b/src/objs/nkchat_message_obj.erl
@@ -93,7 +93,7 @@ create(Conv, Opts) ->
                     {error, Error}
             end;
         {_, _, _, true} ->
-            {error, converation_is_closed};
+            {error, conversation_is_closed};
         {error, Error} ->
             {error, Error}
     end.


### PR DESCRIPTION
Now call starting time is taken when the other peer joins the call and the total duration (in seconds) is calculated when the call finishes. This way, the correct duration will be stored on the ES object and displayed in the automatic message from the direct conversation between both peers.

By adding this new field to the ES mapping, we can now track the duration of calls made in a certain domain or by a specific user. 

Also fixed a typo in nkchat_message_obj:create