### PR TITLE
Added typing command to chat.session.

### DIFF
--- a/src/nkchat_callbacks.erl
+++ b/src/nkchat_callbacks.erl
@@ -41,7 +41,7 @@ error(user_hangup)                      -> "User started hangup";
 
 
 error(conversation_not_found)           -> "Conversation not found";
-error(conversation_is_already_present)   -> "Conversation is already a member";
+error(conversation_is_already_present)  -> "Conversation is already a member";
 error(conversation_is_disabled)         -> "Conversation is currently disabled";
 error(conversation_is_closed)           -> "Conversation is closed";
 error(invite_not_found)                 -> "Invite not found";

--- a/src/objs/nkchat_conversation.erl
+++ b/src/objs/nkchat_conversation.erl
@@ -32,6 +32,7 @@
 -export([get_recent_conversations/3]).
 -export([get_pretty_name/1, is_direct_conversation/1]).
 -export([mute/3, is_muted/2, get_muted_tag/1]).
+-export([typing/2]).
 -export([added_invitation/4, add_invite_op/4, perform_op/1]).
 -export([message_event/2]).
 -export([sync_op/2, async_op/2]).
@@ -335,6 +336,11 @@ is_muted(Id, MemberId) ->
 %% @doc
 get_muted_tag(MemberId) ->
     <<(nklib_util:to_binary(MemberId))/binary, ":", "muted">>.
+
+
+%% @doc
+typing(Id, MemberId) ->
+    async_op(Id, {typing, nklib_util:to_binary(MemberId)}).
 
 
 %% @doc

--- a/src/objs/nkchat_conversation_obj_events.erl
+++ b/src/objs/nkchat_conversation_obj_events.erl
@@ -32,11 +32,26 @@
 
 
 %% @private
+event({added_to_conversation, MemberId}, #obj_state{id=#obj_id_ext{obj_id=ConvId}}=State) ->
+    {event, {added_to_conversation, MemberId, #{conversation_id=>ConvId}}, State};
+
 event({invite_added, InviteData}, State) ->
     {event, {invite_added, InviteData}, State};
 
 event({invite_removed, UserId}, State) ->
     {event, {invite_removed, #{user_id=>UserId}}, State};
+
+event({member_added, MemberId}, State) ->
+    {event, {member_added, #{member_id=>MemberId}}, State};
+
+event({member_muted, MemberId, Muted}, State) ->
+    {event, {member_muted, #{member_id=>MemberId, is_muted=>Muted}}, State};
+
+event({member_removed, MemberId}, State) ->
+    {event, {member_removed, #{member_id=>MemberId}}, State};
+
+event({member_typing, MemberId}, State) ->
+    {event, {member_typing, #{member_id=>MemberId}}, State};
 
 event({message_created, #{obj_id:=MsgId}}, State) ->
     {event, {message_created, #{message_id=>MsgId}}, State};
@@ -46,18 +61,6 @@ event({message_updated, #{obj_id:=MsgId}}, State) ->
 
 event({message_deleted, MsgId}, State) ->
     {event, {message_deleted, #{message_id=>MsgId}}, State};
-
-event({member_added, MemberId}, State) ->
-    {event, {member_added, #{member_id=>MemberId}}, State};
-
-event({added_to_conversation, MemberId}, #obj_state{id=#obj_id_ext{obj_id=ConvId}}=State) ->
-    {event, {added_to_conversation, MemberId, #{conversation_id=>ConvId}}, State};
-
-event({member_removed, MemberId}, State) ->
-    {event, {member_removed, #{member_id=>MemberId}}, State};
-
-event({member_muted, MemberId, Muted}, State) ->
-    {event, {member_muted, #{member_id=>MemberId, is_muted=>Muted}}, State};
 
 event({removed_from_conversation, MemberId}, #obj_state{id=#obj_id_ext{obj_id=ConvId}}=State) ->
     {event, {removed_from_conversation, MemberId, #{conversation_id=>ConvId}}, State};

--- a/src/objs/nkchat_session_obj_cmd.erl
+++ b/src/objs/nkchat_session_obj_cmd.erl
@@ -38,8 +38,9 @@
     <<"invite_added">>,
     <<"invite_removed">>,
     <<"member_added">>,
-    <<"member_removed">>,
     <<"member_muted">>,
+    <<"member_removed">>,
+    <<"member_typing">>,
     <<"message_created">>,
     <<"message_udpdated">>,
     <<"message_deleted">>,
@@ -198,6 +199,14 @@ cmd(<<"reject_invitation">>, #nkreq{data=#{token:=TokenId}=Data}=Req) ->
     case nkdomain_api_util:get_id(?CHAT_SESSION, Data, Req) of
         {ok, Id} ->
             nkchat_session_obj:reject_invitation(Id, TokenId);
+        {error, Error} ->
+            {error, Error}
+    end;
+
+cmd(<<"typing">>, #nkreq{data=Data}=Req) ->
+    case nkdomain_api_util:get_id(?CHAT_SESSION, Data, Req) of
+        {ok, Id} ->
+            nkchat_session_obj:typing(Id);
         {error, Error} ->
             {error, Error}
     end;

--- a/src/objs/nkchat_session_obj_events.erl
+++ b/src/objs/nkchat_session_obj_events.erl
@@ -49,14 +49,24 @@ event({invite_added, ConvId, InviteData}, State) ->
 event({invite_removed, ConvId, UserId}, State) ->
     {event, {invite_removed, #{conversation_id=>ConvId, user_id=>UserId}}, State};
 
+event({invited_to_conversation, TokenId, UserId, ConvId}, State) ->
+    Data = #{token_id=>TokenId, user_id=>UserId, conversation_id=>ConvId},
+    {event, {invited_to_conversation, Data}, State};
+
+event({is_closed_updated, ConvId, IsClosed}, State) ->
+    {event, {is_closed_updated, #{conversation_id=>ConvId, is_closed=>IsClosed}}, State};
+
 event({member_added, ConvId, MemberId}, State) ->
     {event, {member_added, #{conversation_id=>ConvId, member_id=>MemberId}}, State};
+
+event({member_muted, ConvId, MemberId, Muted}, State) ->
+    {event, {member_muted, #{conversation_id=>ConvId, member_id=>MemberId, is_muted=>Muted}}, State};
 
 event({member_removed, ConvId, MemberId}, State) ->
     {event, {member_removed, #{conversation_id=>ConvId, member_id=>MemberId}}, State};
 
-event({member_muted, ConvId, MemberId, Muted}, State) ->
-    {event, {member_muted, #{conversation_id=>ConvId, member_id=>MemberId, is_muted=>Muted}}, State};
+event({member_typing, ConvId, MemberId}, State) ->
+    {event, {member_typing, #{conversation_id=>ConvId, member_id=>MemberId}}, State};
 
 event({message_created, ConvId, Msg}, State) ->
     {event, {message_created, #{conversation_id=>ConvId, message=>Msg}}, State};
@@ -67,21 +77,14 @@ event({message_updated, ConvId, Msg}, State) ->
 event({message_deleted, ConvId, MsgId}, State) ->
     {event, {message_deleted, #{conversation_id=>ConvId, message_id=>MsgId}}, State};
 
+event({remove_notification, TokenId, Reason}, State) ->
+    {event, {remove_notification, #{token_id=>TokenId, reason=>Reason}}, State};
+
 event({status_updated, ConvId, Status}, State) ->
     {event, {status_updated, #{conversation_id=>ConvId, status=>Status}}, State};
 
-event({is_closed_updated, ConvId, IsClosed}, State) ->
-    {event, {is_closed_updated, #{conversation_id=>ConvId, is_closed=>IsClosed}}, State};
-
 event({unread_counter_updated, ConvId, Counter}, State) ->
     {event, {unread_counter_updated, #{conversation_id=>ConvId, counter=>Counter}}, State};
-
-event({invited_to_conversation, TokenId, UserId, ConvId}, State) ->
-    Data = #{token_id=>TokenId, user_id=>UserId, conversation_id=>ConvId},
-    {event, {invited_to_conversation, Data}, State};
-
-event({remove_notification, TokenId, Reason}, State) ->
-    {event, {remove_notification, #{token_id=>TokenId, reason=>Reason}}, State};
 
 event(_Event, State) ->
     {ok, State}.

--- a/src/objs/nkchat_session_obj_syntax.erl
+++ b/src/objs/nkchat_session_obj_syntax.erl
@@ -105,6 +105,11 @@ syntax(<<"launch_notifications">>, Syntax) ->
         id => binary
     };
 
+syntax(<<"typing">>, Syntax) ->
+    Syntax#{
+        id => binary
+    };
+
 syntax(<<"wakeup">>, Syntax) ->
     Syntax#{
         id => binary


### PR DESCRIPTION
Also added typing function and member_typing event to nkchat_conversation.
When a user sends a typing command to an active conversation, a "member_typing" event will be broadcasted to all chat.sessions in that conversation.
Besides, the user who call the typing command will be marked as "active" (that is, with a green badge in the MPS client).