### PR TITLE
Added last_seen_message event

### DIFF
--- a/src/objs/nkchat_conversation_obj_events.erl
+++ b/src/objs/nkchat_conversation_obj_events.erl
@@ -41,6 +41,9 @@ event({invite_added, InviteData}, State) ->
 event({invite_removed, UserId}, State) ->
     {event, {invite_removed, #{user_id=>UserId}}, State};
 
+event({last_seen_message, MemberIds, Time}, State) ->
+    {event, {last_seen_message, #{member_ids => MemberIds, last_seen_message_time => Time}}, State};
+
 event({member_added, MemberId}, State) ->
     {event, {member_added, #{member_id=>MemberId}}, State};
 

--- a/src/objs/nkchat_session_obj.erl
+++ b/src/objs/nkchat_session_obj.erl
@@ -63,6 +63,7 @@
     {invite_removed, ConvId::nkdomain:obj_id(), UserId::nkdomain:obj_id()} |
     {invited_to_conversation, TokenId::binary(), UserId::binary(), ConvId::binary()} |
     {is_closed_updated, boolean()} |
+    {last_seen_message, ConvId::nkdomain:obj_id(), MemberIds::[nkdomain:obj_id()], Time::binary()} |
     {member_added, ConvId::nkdomain:obj_id(), IsActive::boolean(), MemberId::nkdomain:obj_id()} |
     {member_muted, ConvId::nkdomain:obj_id(), IsActive::boolean(), MemberId::nkdomain:obj_id(), IsMuted::boolean()} |
     {member_removed, ConvId::nkdomain:obj_id(), IsActive::boolean(), MemberId::nkdomain:obj_id()} |
@@ -632,6 +633,9 @@ do_conversation_event({invite_removed, UserId}, ConvId, State) ->
 
 do_conversation_event({is_closed_updated, IsClosed}, ConvId, State) ->
     {noreply, do_event({is_closed_updated, ConvId, IsClosed}, State)};
+
+do_conversation_event({last_seen_message, MemberIds, Time}, ConvId, State) ->
+    {noreply, do_event({last_seen_message, ConvId, MemberIds, Time}, State)};
 
 do_conversation_event({member_added, MemberId}, ConvId, State) ->
     {noreply, do_event({member_added, ConvId, MemberId}, State)};

--- a/src/objs/nkchat_session_obj_cmd.erl
+++ b/src/objs/nkchat_session_obj_cmd.erl
@@ -37,6 +37,7 @@
     <<"conversation_updated">>,
     <<"invite_added">>,
     <<"invite_removed">>,
+    <<"last_seen_message">>,
     <<"member_added">>,
     <<"member_muted">>,
     <<"member_removed">>,

--- a/src/objs/nkchat_session_obj_events.erl
+++ b/src/objs/nkchat_session_obj_events.erl
@@ -56,6 +56,9 @@ event({invited_to_conversation, TokenId, UserId, ConvId}, State) ->
 event({is_closed_updated, ConvId, IsClosed}, State) ->
     {event, {is_closed_updated, #{conversation_id=>ConvId, is_closed=>IsClosed}}, State};
 
+event({last_seen_message, ConvId, MemberIds, Time}, State) ->
+    {event, {last_seen_message, #{conversation_id=>ConvId, member_ids=>MemberIds, last_seen_message_time=>Time}}, State};
+
 event({member_added, ConvId, MemberId}, State) ->
     {event, {member_added, #{conversation_id=>ConvId, member_id=>MemberId}}, State};
 


### PR DESCRIPTION
This new event is sent to all registered chat.sessions:
- When a user activates a conversation with unread messages
- When there is a new message and, at least, one active chat.session in that conversation

The event will have the conversation_id, the list of members that "read" the message and the creation time of the last message read.