### PR TITLE
Added a new member to a conversation with the current messages marked…

### DIFF
--- a/src/objs/nkchat_conversation_obj_events.erl
+++ b/src/objs/nkchat_conversation_obj_events.erl
@@ -44,8 +44,8 @@ event({invite_removed, UserId}, State) ->
 event({last_seen_message, MemberIds, Time}, State) ->
     {event, {last_seen_message, #{member_ids => MemberIds, last_seen_message_time => Time}}, State};
 
-event({member_added, MemberId}, State) ->
-    {event, {member_added, #{member_id=>MemberId}}, State};
+event({member_added, MemberId, MemberData}, State) ->
+    {event, {member_added, MemberData#{member_id=>MemberId}}, State};
 
 event({member_muted, MemberId, Muted}, State) ->
     {event, {member_muted, #{member_id=>MemberId, is_muted=>Muted}}, State};

--- a/src/objs/nkchat_session_obj.erl
+++ b/src/objs/nkchat_session_obj.erl
@@ -64,8 +64,8 @@
     {invited_to_conversation, TokenId::binary(), UserId::binary(), ConvId::binary()} |
     {is_closed_updated, boolean()} |
     {last_seen_message, ConvId::nkdomain:obj_id(), MemberIds::[nkdomain:obj_id()], Time::binary()} |
-    {member_added, ConvId::nkdomain:obj_id(), IsActive::boolean(), MemberId::nkdomain:obj_id()} |
-    {member_muted, ConvId::nkdomain:obj_id(), IsActive::boolean(), MemberId::nkdomain:obj_id(), IsMuted::boolean()} |
+    {member_added, ConvId::nkdomain:obj_id(), MemberId::nkdomain:obj_id(), MemberData::map()} |
+    {member_muted, ConvId::nkdomain:obj_id(), MemberId::nkdomain:obj_id(), IsMuted::boolean()} |
     {member_removed, ConvId::nkdomain:obj_id(), IsActive::boolean(), MemberId::nkdomain:obj_id()} |
     {member_typing, ConvId::nkdomain:obj_id(), MemberId::nkdomain:obj_id()} |
     {message_created, nkdomain:obj()} |
@@ -637,8 +637,8 @@ do_conversation_event({is_closed_updated, IsClosed}, ConvId, State) ->
 do_conversation_event({last_seen_message, MemberIds, Time}, ConvId, State) ->
     {noreply, do_event({last_seen_message, ConvId, MemberIds, Time}, State)};
 
-do_conversation_event({member_added, MemberId}, ConvId, State) ->
-    {noreply, do_event({member_added, ConvId, MemberId}, State)};
+do_conversation_event({member_added, MemberId, MemberData}, ConvId, State) ->
+    {noreply, do_event({member_added, ConvId, MemberId, MemberData}, State)};
 
 do_conversation_event({member_muted, MemberId, IsMuted}, ConvId, State) ->
     {noreply, do_event({member_muted, ConvId, MemberId, IsMuted}, State)};

--- a/src/objs/nkchat_session_obj_events.erl
+++ b/src/objs/nkchat_session_obj_events.erl
@@ -59,8 +59,8 @@ event({is_closed_updated, ConvId, IsClosed}, State) ->
 event({last_seen_message, ConvId, MemberIds, Time}, State) ->
     {event, {last_seen_message, #{conversation_id=>ConvId, member_ids=>MemberIds, last_seen_message_time=>Time}}, State};
 
-event({member_added, ConvId, MemberId}, State) ->
-    {event, {member_added, #{conversation_id=>ConvId, member_id=>MemberId}}, State};
+event({member_added, ConvId, MemberId, MemberData}, State) ->
+    {event, {member_added, MemberData#{conversation_id=>ConvId, member_id=>MemberId}}, State};
 
 event({member_muted, ConvId, MemberId, Muted}, State) ->
     {event, {member_muted, #{conversation_id=>ConvId, member_id=>MemberId, is_muted=>Muted}}, State};


### PR DESCRIPTION
… as seen.

This change will avoid a huge unread badge counter for conversations with multiple messages and also changing a double blue check to a double grey check between accepting an invitation and entering for the first time to said conversation.
Also changed member_added to add missing information about the new member to keep UI client updated.