### PR TITLE
Added read_previous to add_member and send_invitation.

### DIFF
--- a/include/nkchat.hrl
+++ b/include/nkchat.hrl
@@ -36,6 +36,10 @@
 -define(CHAT_MSG_TYPE_ALERT, <<"chat.alert">>).
 
 
+-define(DEFAULT_SILENT, false).
+-define(DEFAULT_READ_PREVIOUS, false).
+
+
 %% ===================================================================
 %% Records
 %% ===================================================================

--- a/src/objs/nkchat_conversation_obj_cmd.erl
+++ b/src/objs/nkchat_conversation_obj_cmd.erl
@@ -34,7 +34,7 @@
 %% ===================================================================
 
 cmd(<<"add_member">>, #nkreq{data=#{id:=ConvId, member_id:=MemberId}=Data}) ->
-    Opts = maps:with([silent], Data),
+    Opts = maps:with([silent, read_previous], Data),
     case nkchat_conversation:add_member(ConvId, MemberId, Opts) of
         {ok, MemberObjId} ->
             {ok, #{<<"member_id">>=>MemberObjId}};

--- a/src/objs/nkchat_conversation_obj_view.erl
+++ b/src/objs/nkchat_conversation_obj_view.erl
@@ -201,7 +201,7 @@ update(ObjId, Data, _Session) ->
                 {ok, _} ->
                     lists:map(
                         fun(M) ->
-                            nkchat_conversation:add_member(ObjId, M, #{silent => true})
+                            nkchat_conversation:add_member(ObjId, M, #{silent => true, read_previous => true})
                         end,
                         ToAdd),
                     lists:map(

--- a/src/objs/nkchat_session_obj_cmd.erl
+++ b/src/objs/nkchat_session_obj_cmd.erl
@@ -178,7 +178,8 @@ cmd(<<"send_invitation">>, #nkreq{data=#{member_id:=MemberId, conversation_id:=C
     case nkdomain_api_util:get_id(?CHAT_SESSION, Data, Req) of
         {ok, Id} ->
             TTL = maps:get(ttl, Data, 0),
-            case nkchat_session_obj:send_invitation(Id, MemberId, ConvId, TTL) of
+            Opts = maps:with([silent, read_previous], Data),
+            case nkchat_session_obj:send_invitation(Id, MemberId, ConvId, TTL, Opts) of
                 {ok, _TokenId} ->
                     ok;
                 {error, Error} ->

--- a/src/objs/nkchat_session_obj_syntax.erl
+++ b/src/objs/nkchat_session_obj_syntax.erl
@@ -83,7 +83,13 @@ syntax(<<"send_invitation">>, Syntax) ->
         member_id => binary,
         conversation_id => binary,
         ttl => {integer, 0, none},
-        '__mandatory' => [member_id, conversation_id]
+        silent => boolean,
+        read_previous => boolean,
+        '__mandatory' => [member_id, conversation_id],
+        '__defaults' => #{
+            silent => ?DEFAULT_SILENT,
+            read_previous => ?DEFAULT_READ_PREVIOUS
+        }
     };
 
 syntax(<<"accept_invitation">>, Syntax) ->


### PR DESCRIPTION
This will allow adding a new member to a conversation, directly or through an invitation, and select whether we add that member silently (without creating an automatic message) and if the previous messages should be marked as read or not.